### PR TITLE
Changed module name mate1 to mate in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To recreate the CTF environment with docker:
 ./docker_build.sh <module_name>
 ./docker_run.sh <module_name>
 ```
-module_names: {billboard, giftwrapper, giftwrapper2, mate1, mate2, shredder}
+module_names: {billboard, giftwrapper, giftwrapper2, mate, mate2, shredder}
 
 
 Connect to the service:


### PR DESCRIPTION
Hi Tharina,

the Readme.md file tells users to build the image using ./docker_build.sh mate1. Using mate1 will cause the build to fail. 
So I changed the argument to mate.

 